### PR TITLE
fix(xform): fix cancel not reverting form field values

### DIFF
--- a/demo/package-lock.json
+++ b/demo/package-lock.json
@@ -6682,12 +6682,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -6702,17 +6704,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -6829,7 +6834,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -6841,6 +6847,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -6855,6 +6862,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -6862,12 +6870,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -6886,6 +6896,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -6966,7 +6977,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -6978,6 +6990,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -7099,6 +7112,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",

--- a/demo/src/app/home/home.component.html
+++ b/demo/src/app/home/home.component.html
@@ -37,7 +37,8 @@
         </div>
       </fieldset>
     </form>
-    <hr />
+    <hr/>
+    <!-- The actual form component -->
     <div class="panel-body">
       <ng-xform-edit-save
         [fields]="fields"
@@ -49,8 +50,11 @@
       <hr>
       <pre>{{ model | json }}</pre>
     </div>
+
   </div>
 </section>
+
+<!-- Custom Field -->
 <ng-template #customField let-customControl="control" let-isEditing="isEditing">
   <div class="input-group">
     <div class="input-group-addon">$</div>

--- a/demo/src/app/home/home.component.ts
+++ b/demo/src/app/home/home.component.ts
@@ -41,7 +41,7 @@ export class HomeComponent implements OnInit, OnDestroy {
     { id: 6, name: 'purple' }
   ];
 
-  public onchangefn = new Subject<string>();
+  public onOptFieldChange = new Subject<string>();
 
   public fields: DynamicField[];
   public horizontal = false;
@@ -49,17 +49,21 @@ export class HomeComponent implements OnInit, OnDestroy {
   public labelWidth = 2;
   public model: any;
   public outputhelper = {'A': 1, 'B': 2, 'C': 3};
-  public subscriptions: Subscription[] = [];
+  public subscriptions: Subscription;
 
-  constructor(private titleService: Title, private http: HttpClient) { }
+  constructor(private titleService: Title, private http: HttpClient) {
+    this.subscriptions = new Subscription();
+  }
 
   ngOnInit() {
     const minDate = new Date();
     const maxDate = new Date();
 
-    this.subscriptions.push(this.onchangefn.asObservable().subscribe(
-      (value: any) =>  this.xformComponent.setValue({'outputopt': this.outputhelper[value]})
-    ));
+    this.subscriptions.add(
+      this.onOptFieldChange.asObservable().subscribe(
+        (value: any) =>  this.xformComponent.xform.patchValue({'output_opt': this.outputhelper[value]})
+      )
+    );
 
     minDate.setDate(minDate.getDate() - 3);
     maxDate.setDate(maxDate.getDate() + 3);
@@ -158,11 +162,11 @@ export class HomeComponent implements OnInit, OnDestroy {
         optionLabelKey: 'description',
         optionValueKey: 'id',
         onChangeFn: (value: string) => {
-          this.onchangefn.next(value);
+          this.onOptFieldChange.next(value);
         }
       }),
       new TextField({
-        key: 'outputopt',
+        key: 'output_opt',
         label: 'Output of option',
         readOnly: true,
       }),
@@ -204,7 +208,7 @@ export class HomeComponent implements OnInit, OnDestroy {
   }
 
   ngOnDestroy() {
-    this.subscriptions.forEach(sub => sub.unsubscribe());
+    this.subscriptions.unsubscribe();
   }
 
   public onSubmit(values: object) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@esss/ng-xform",
-  "version": "0.22.3",
+  "version": "0.24.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/ng-xform/field-components/base-dynamic-field.component.ts
+++ b/src/ng-xform/field-components/base-dynamic-field.component.ts
@@ -18,18 +18,22 @@ export class BaseDynamicFieldComponent<T extends DynamicField> implements OnInit
   visible = true;
   public hideLabelOnEdit = false;
 
-  protected subscriptions: Subscription[] = [];
+  protected subscriptions: Subscription;
 
   /** If true, the read-only state will show the value obtained from the formattedValue method;
    * otherwise, will keep the component to manage this behavior.
    */
   public useFormattedValueOnReadonly = true;
 
+  constructor() {
+    this.subscriptions = new Subscription();
+  }
+
   ngOnInit() {
     this.control = this.form.controls[this.elementId] as FormControl;
     if (this.field.visibilityFn) {
       const formRoot = this.form.root; // Make sure to get the root form, even for nested FromGroups
-      this.subscriptions.push(formRoot.valueChanges.subscribe(val => {
+      this.subscriptions.add(formRoot.valueChanges.subscribe(val => {
         this.visible = this.field.visibilityFn(val);
         if (!this.visible && !this.field.keepValueWhenHiding) {
           this.control.setValue(null, { emitEvent: false });
@@ -39,17 +43,17 @@ export class BaseDynamicFieldComponent<T extends DynamicField> implements OnInit
     }
 
     if (this.field.onChangeFn) {
-      this.subscriptions.push(this.control.valueChanges.subscribe(val => {
-        this.field.onChangeFn(val);
-      }));
+      this.subscriptions.add(
+        this.control.valueChanges.subscribe(val => {
+          this.field.onChangeFn(val);
+        })
+      );
     }
 
   }
 
   ngOnDestroy() {
-    if (this.subscriptions) {
-      this.subscriptions.forEach(sub => sub.unsubscribe());
-    }
+    this.subscriptions.unsubscribe()
   }
 
   /**

--- a/src/ng-xform/measure-field/measure-field.component.ts
+++ b/src/ng-xform/measure-field/measure-field.component.ts
@@ -50,7 +50,7 @@ export class MeasureFieldComponent extends BaseDynamicFieldComponent<MeasureFiel
   }
 
   ngOnDestroy() {
-    this.subscriptions.forEach(sub => sub.unsubscribe());
+    this.subscriptions.unsubscribe();
   }
 
   onViewChange(value: any) {

--- a/src/ng-xform/ng-xform-edit-save/ng-xform-edit-save.component.ts
+++ b/src/ng-xform/ng-xform-edit-save/ng-xform-edit-save.component.ts
@@ -33,31 +33,33 @@ export class NgXformEditSaveComponent {
   @Output() cancel = new EventEmitter();
 
   @ViewChild('xform') xform: NgXformComponent;
-
-  protected beforeEditingValue = {};
+  /** Copy the model values beofre switch to edit mode to restore
+   * form values in case user cancel the edition */
+  protected valueBeforeEdit = {};
 
   setEditing(editing: boolean) {
     this.editing = editing;
     if (!editing) {
-      this.xform.setValue({... this.beforeEditingValue});
+      this.xform.setValue({... this.valueBeforeEdit});
     }
   }
 
   onSubmit() {
     if (this.xform.isFormValid()) {
-      this.submit.emit(this.xform.getModel());
+      this.submit.emit(this.xform.getValue());
+      this.valueBeforeEdit = this.xform.getValue();
       this.editing = false;
     }
   }
 
   onCancel() {
     this.cancel.emit();
-    this.xform.setValue(this.beforeEditingValue);
+    this.xform.setValue(this.valueBeforeEdit);
     this.editing = false;
   }
 
-  setValue(newModel: any) {
-    this.beforeEditingValue = {... newModel};
-    this.xform.setValue(newModel);
+  setValue(model: any) {
+    this.valueBeforeEdit = {... model};
+    this.xform.setValue(model);
   }
 }

--- a/src/ng-xform/ng-xform.component.spec.ts
+++ b/src/ng-xform/ng-xform.component.spec.ts
@@ -136,7 +136,7 @@ describe('NgXformComponent', () => {
     input.nativeElement.dispatchEvent(new Event('input'));
     expect(component.form.value['nested2']).toBeTruthy();
     expect(component.form.value['nested2']['field1']).toBe('some value');
-    let formValue = component.getModel()
+    let formValue = component.getValue()
     expect(formValue.nested2.field1).toBe('some value');
     expect(formValue.address.extra_field).toBe(model.address.extra_field);
     expect(component.form.valid).toBeTruthy();
@@ -155,11 +155,13 @@ describe('NgXformComponent', () => {
     input.nativeElement.dispatchEvent(new Event('input'));
     expect(component.form.value['nested2']).toBeTruthy();
     expect(component.form.value['nested2']['field1']).toBe('some value');
-    let formValue = component.getModel()
+    let formValue = component.getValue()
     expect(formValue.nested2.field1).toBe('some value');
 
     fixture.detectChanges();
-    expect(component.form.valid).toBeTruthy();
+    // Fill required fill to check for form validity
+    component.form.controls['required'].setValue('some')
+    expect(component.isFormValid()).toBeTruthy();
   });
 
   it('should be read mode', () => {

--- a/src/ng-xform/ng-xform.component.ts
+++ b/src/ng-xform/ng-xform.component.ts
@@ -26,15 +26,14 @@ export class NgXformComponent implements OnInit, OnChanges {
   @Input() horizontalForm = false;
   @Input() labelWidth: number;
   @Output() editingChange = new EventEmitter();
-
   /** To listening submitSuccessful event */
   @Output() submit = new EventEmitter();
-
   /** To listening submitSuccessful event */
   @Output() cancel = new EventEmitter();
 
-  model: any = null;
   form: FormGroup;
+  /** Store form fields initial values. `null` for and empty form */
+  initialModel: any = null;
 
   ngOnInit() {
     this.createForm();
@@ -51,7 +50,7 @@ export class NgXformComponent implements OnInit, OnChanges {
     this.reset();
   }
 
-  createFormGroup(fields: DynamicField[]): FormGroup {
+  protected createFormGroup(fields: DynamicField[]): FormGroup {
     const group: any = {};
 
     fields.forEach(field => {
@@ -87,13 +86,13 @@ export class NgXformComponent implements OnInit, OnChanges {
 
   reset() {
     this.form.reset();
-    if (this.model) {
-      this.form.patchValue(this.model, { onlySelf: true });
+    if (this.initialModel) {
+      this.form.patchValue(this.initialModel, { onlySelf: true });
     }
   }
 
   clear() {
-    this.model = null;
+    this.initialModel = null;
     this.form.reset();
   }
 
@@ -111,17 +110,30 @@ export class NgXformComponent implements OnInit, OnChanges {
    * Note: Calling setValue(null) will not clear the form. Use clear() instead.
    */
   setValue(value: any) {
-    this.model = value;
-    this.form.patchValue(this.model);
+    this.clear();
+    if (value != null) {
+      this.initialModel = value;
+      // Use patchValue so it won't fail if model has extra properties that are
+      // not mapped as Form fields.
+      this.patchValue(this.initialModel);
+    }
+  }
+
+  patchValue(value: any) {
+    this.form.patchValue(value);
+  }
+
+  getValue() {
+    return this.unpatchValue(this.form, this.initialModel);
   }
 
   getModel() {
-    return this.unpatchValue(this.form, this.model);
+    console.warn('"getModel" is deprecated. Use "getValue"');
+    return this.getValue();
   }
 
   /**
-   * Touch all form fields to force field validations to run, and display validation message in
-   * invalid inputs.
+   * Touch all form fields to force field validations to run
    *
    * @param formGroup the control group to be touched.
    */


### PR DESCRIPTION
This is a regression bug. Form was not reverting field values when
user clicked in Cancel button.

Change ng-xform-edit-save component to copy form values before editing
and use patchValue to set them again after a Cancel operation.