### PR TITLE
fix(ngxform): fix measure field value not reseting

### DIFF
--- a/src/ng-xform/measure-field/measure-field.component.spec.ts
+++ b/src/ng-xform/measure-field/measure-field.component.spec.ts
@@ -65,24 +65,24 @@ describe('MeasureFieldComponent', () => {
 
     inputEl.nativeElement.value = newValueString;
     inputEl.nativeElement.dispatchEvent(new Event('input'));
-    expect(component.control.value).toEqual(new Measure(15, 'm'));
+    expect(component.formattedValue).toEqual('15 m');
 
     component.changeUnit('cm');
     expect(component.viewModel).toEqual(1500);
     expect(component.viewUnit).toEqual('cm');
-    expect(component.control.value).toEqual(new Measure(15, 'm'));
+    expect(component.formattedValue).toEqual('1500 cm');
 
     component.changeUnit('');
     expect(component.viewModel).toEqual(15);
     expect(component.viewUnit).toEqual('m');
-    expect(component.control.value).toEqual(new Measure(15, 'm'));
+    expect(component.formattedValue).toEqual('15 m');
 
     component.field.modelUnit = 'inch';
     fixture.detectChanges();
     component.ngOnInit();
     inputEl.nativeElement.value = newValueString;
     inputEl.nativeElement.dispatchEvent(new Event('input'));
-    expect(component.control.value).toEqual(new Measure(15, 'inch'));
+    expect(component.formattedValue).toEqual('15 inch');
   });
 
   it('should show unit and units dropdown', () => {

--- a/src/ng-xform/measure-field/measure-field.component.ts
+++ b/src/ng-xform/measure-field/measure-field.component.ts
@@ -69,8 +69,7 @@ export class MeasureFieldComponent extends BaseDynamicFieldComponent<MeasureFiel
         this.field.modelUnit
       );
     }
-
-    this.control.setValue(newValue, { emitModelToViewChange: false });
+    this.updateInputValue();
     this._onChange(newValue);
   }
 


### PR DESCRIPTION
Measure field was preserving the changed value even when Form edition
was canceled.